### PR TITLE
chore: don't run ci on renovate/dependabot updates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,6 +54,12 @@ steps:
         exclude:
           - pull_request
 
+trigger:
+  branch:
+    exclude:
+      - renovate/*
+      - dependabot/*
+
 volumes:
   - name: docker-socket
     host:
@@ -82,6 +88,10 @@ steps:
         - failure
 
 trigger:
+  branch:
+    exclude:
+      - renovate/*
+      - dependabot/*
   status:
     - success
     - failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3.16.2
 
 # https://github.com/twistedpair/google-cloud-sdk/ is a mirror that replicates the gcloud sdk versions
 # renovate: datasource=github-tags depName=twistedpair/google-cloud-sdk
-ARG CLOUD_SDK_VERSION=401.0.0
+ARG CLOUD_SDK_VERSION=402.0.0
 # renovate: datasource=github-releases depName=docker/buildx
 ARG BUILDX_VERSION=v0.9.1
 # renovate: datasource=github-releases depName=git-chglog/git-chglog extractVersion=^v(?<version>.*)$


### PR DESCRIPTION
Disable ci for renovate/dependabot updates.

Signed-off-by: Noel Georgi <git@frezbo.dev>