### PR TITLE
feat: add explicit buildkit GC configuration

### DIFF
--- a/hack/scripts/buildkit.toml
+++ b/hack/scripts/buildkit.toml
@@ -1,0 +1,11 @@
+[worker.oci]
+  gc = true
+  gckeepstorage = 100000 # 100 GiB
+
+  [[worker.oci.gcpolicy]]
+    keepBytes = 32212254720 # 30 GiB
+    keepDuration = 604800
+    filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+  [[worker.oci.gcpolicy]]
+    all = true
+    keepBytes = 107374182400 # 100 GiB

--- a/hack/scripts/setup-buildx-amd64-arm64
+++ b/hack/scripts/setup-buildx-amd64-arm64
@@ -5,5 +5,5 @@ set -eou pipefail
 # renovate: datasource=github-releases depName=moby/buildkit
 BUILDKIT_IMAGE="docker.io/moby/buildkit:v0.11.6"
 
-docker buildx create --driver docker-container --platform linux/amd64 --name xbuild --use --driver-opt image=${BUILDKIT_IMAGE}
-docker buildx create --append --name xbuild --platform linux/arm64 tcp://docker-arm64.ci.svc:2376 --driver-opt image=${BUILDKIT_IMAGE}
+docker buildx create --driver docker-container --platform linux/amd64 --name xbuild --use --driver-opt image=${BUILDKIT_IMAGE} --config /usr/local/bin/buildkit.toml
+docker buildx create --append --name xbuild --platform linux/arm64 tcp://docker-arm64.ci.svc:2376 --driver-opt image=${BUILDKIT_IMAGE} --config /usr/local/bin/buildkit.toml

--- a/hack/scripts/setup-ci
+++ b/hack/scripts/setup-ci
@@ -13,11 +13,13 @@ function setup_buildkit() {
     --name ci --buildkitd-flags "--allow-insecure-entitlement security.insecure" --driver-opt image=${BUILDKIT_IMAGE} \
     --platform linux/amd64 \
     --driver docker-container  \
+    --config /usr/local/bin/buildkit.toml \
     --use unix:///var/outer-run/docker.sock
 
   docker buildx create \
     --name ci --buildkitd-flags "--allow-insecure-entitlement security.insecure" --driver-opt image=${BUILDKIT_IMAGE} \
     --platform linux/arm64 \
+    --config /usr/local/bin/buildkit.toml \
     --append \
     tcp://docker-arm64.ci.svc:2376
 
@@ -29,6 +31,7 @@ function setup_buildkit_cross() {
   docker buildx create \
     --name ci --buildkitd-flags "--allow-insecure-entitlement security.insecure" --driver-opt image=${BUILDKIT_IMAGE} \
     --platform linux/amd64,linux/arm64 \
+    --config /usr/local/bin/buildkit.toml \
     --driver docker-container  \
     --use unix:///var/outer-run/docker.sock
 


### PR DESCRIPTION
Looks like buildkit is doing too aggressive GC, which leads to crazy slow builds.