### PR TITLE
feat: update buildkit to 0.12.2

### DIFF
--- a/hack/scripts/setup-buildx-amd64-arm64
+++ b/hack/scripts/setup-buildx-amd64-arm64
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 # renovate: datasource=github-releases depName=moby/buildkit
-BUILDKIT_IMAGE="docker.io/moby/buildkit:v0.11.6"
+BUILDKIT_IMAGE="docker.io/moby/buildkit:v0.12.2"
 
 docker buildx create --driver docker-container --platform linux/amd64 --name xbuild --use --driver-opt image=${BUILDKIT_IMAGE} --config /usr/local/bin/buildkit.toml
 docker buildx create --append --name xbuild --platform linux/arm64 tcp://docker-arm64.ci.svc:2376 --driver-opt image=${BUILDKIT_IMAGE} --config /usr/local/bin/buildkit.toml

--- a/hack/scripts/setup-ci
+++ b/hack/scripts/setup-ci
@@ -5,7 +5,7 @@ set -ex
 export TAG=$(git log --oneline --format=%B -n 1 HEAD | head -n 1 | sed -r "/^release\(/ s/^release\((.*)\):.*$/\\1/; t; Q")
 
 # renovate: datasource=github-releases depName=moby/buildkit
-BUILDKIT_IMAGE="docker.io/moby/buildkit:v0.11.6"
+BUILDKIT_IMAGE="docker.io/moby/buildkit:v0.12.2"
 
 # setup buildkit across amd64/arm64 workers
 function setup_buildkit() {


### PR DESCRIPTION
The buildkit 0.12 drops the `moby.buildkit.buildinfo.v1` annotation which breaks the image reproducibility for some container images.