### PR TITLE
fix: rollback alpine to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG DOCKER=docker:25.0.2-dind
 
 FROM $DOCKER as docker
 
-FROM alpine:3.19.1
+FROM alpine:3.18.4
 
 # https://github.com/twistedpair/google-cloud-sdk/ is a mirror that replicates the gcloud sdk versions
 # renovate: datasource=github-tags depName=twistedpair/google-cloud-sdk


### PR DESCRIPTION
We suspect it might be causing issues with SecureBoot.