### PR TITLE
chore: bump actions runner version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:questing-20251217 AS build
 ARG TARGETOS
 ARG TARGETARCH
 # renovate: datasource=github-releases depName=actions/runner
-ARG RUNNER_VERSION=2.333.1
+ARG RUNNER_VERSION=2.335.1
 # update these together with RUNNER_VERSION from upstream
 ARG RUNNER_CONTAINER_HOOKS_VERSION=0.7.0
 ARG DOCKER_VERSION=29.3.1

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ docker-%:  ## Builds the specified target defined in the Pkgfile using the docke
 
 .PHONY: build-container
 build-container:
-	@$(MAKE) docker-actions-runner TARGET_ARGS="--push=$(PUSH)" TAG="2.333.1-25.10"
+	@$(MAKE) docker-actions-runner TARGET_ARGS="--push=$(PUSH)" TAG="2.335.1-25.10"
 
 .PHONY: rekres
 rekres:


### PR DESCRIPTION
Github chose to deprecate the version of actions runner we were on and it was causing all builders to cease to be :facepalm:.